### PR TITLE
Fix for multiple quality binary downloads (stable/insider)

### DIFF
--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -238,7 +238,7 @@ class VSCUpdates(object):
                             ver = VSCUpdateDefinition(platform, architecture, buildtype, quality)
                             ver.check_for_update()
                             log.info(ver)
-                            versions[ver.identity] = ver
+                            versions[f'{ver.identity}-{ver.quality}'] = ver
         return versions
 
     @staticmethod


### PR DESCRIPTION
Resolves #2 by adding `quality` to the key of the versions dictionary. 