### PR TITLE
Skip extensions with multiple versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,13 @@ services:
       # Enable for dev
       - ./vscoffline/:/opt/vscoffline/:ro
       - ./artifacts/:/artifacts/
+      - ./logs/:/logs/
     environment:
-      - SYNCARGS=--sync
+      # - SYNCARGS=--sync
       # Enable to sync all extensions
       #- SYNCARGS=--syncall
       # Enable a logfile
-      #- SYNCARGS=--sync --logfile /logs/sync.log
+      - SYNCARGS=--syncall --logfile /logs/sync.log --frequency 1w
 
   vscgallery:
     image: lolinternet/vscgallery:latest
@@ -30,7 +31,7 @@ services:
       # Enable for custom SSL certs
       #- ./vscoffline/vscgallery/ssl/:/opt/vscoffline/vscgallery/ssl # Enable for custom SSL certs
       # Enable to store logfiles in its own folder
-      # ./logs/:/logs/
+      - ./logs/:/logs/
     ports:
       - 443:443
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
-version: "3"
+version: '3'
 services:
+
   vscsync:
     image: lolinternet/vscsync:latest
     build:
@@ -22,7 +23,7 @@ services:
     image: lolinternet/vscgallery:latest
     build:
       context: ./
-      dockerfile: ./vscoffline/vscgallery/Dockerfile
+      dockerfile: ./vscoffline/vscgallery/Dockerfile    
     volumes:
       # Enable for dev
       #- ./vscoffline/:/opt/vscoffline/:ro # Enable for dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,29 +1,27 @@
-version: "3"
+version: '3'
 services:
+
   vscsync:
     image: lolinternet/vscsync:latest
     build:
-      context: ./
-      dockerfile: ./vscoffline/vscsync/Dockerfile
-    dns:
+	@@ -10,28 +9,29 @@ services:
       - 1.1.1.1
     volumes:
       # Enable for dev
-      - ./vscoffline/:/opt/vscoffline/:ro
+      #- ./vscoffline/:/opt/vscoffline/:ro
       - ./artifacts/:/artifacts/
-      - ./logs/:/logs/
     environment:
-      # - SYNCARGS=--sync
+      - SYNCARGS=--sync
       # Enable to sync all extensions
       #- SYNCARGS=--syncall
       # Enable a logfile
-      - SYNCARGS=--syncall --logfile /logs/sync.log --frequency 1w
+      #- SYNCARGS=--sync --logfile /logs/sync.log
 
   vscgallery:
     image: lolinternet/vscgallery:latest
     build:
       context: ./
-      dockerfile: ./vscoffline/vscgallery/Dockerfile
+      dockerfile: ./vscoffline/vscgallery/Dockerfile    
     volumes:
       # Enable for dev
       #- ./vscoffline/:/opt/vscoffline/:ro # Enable for dev
@@ -31,8 +29,7 @@ services:
       # Enable for custom SSL certs
       #- ./vscoffline/vscgallery/ssl/:/opt/vscoffline/vscgallery/ssl # Enable for custom SSL certs
       # Enable to store logfiles in its own folder
-      - ./logs/:/logs/
+      # ./logs/:/logs/
     ports:
       - 443:443
     environment:
-      - BIND=0.0.0.0:443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
-version: '3'
+version: "3"
 services:
-
   vscsync:
     image: lolinternet/vscsync:latest
     build:
@@ -10,7 +9,7 @@ services:
       - 1.1.1.1
     volumes:
       # Enable for dev
-      #- ./vscoffline/:/opt/vscoffline/:ro
+      - ./vscoffline/:/opt/vscoffline/:ro
       - ./artifacts/:/artifacts/
     environment:
       - SYNCARGS=--sync
@@ -23,7 +22,7 @@ services:
     image: lolinternet/vscgallery:latest
     build:
       context: ./
-      dockerfile: ./vscoffline/vscgallery/Dockerfile    
+      dockerfile: ./vscoffline/vscgallery/Dockerfile
     volumes:
       # Enable for dev
       #- ./vscoffline/:/opt/vscoffline/:ro # Enable for dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
-version: '3'
+version: "3"
 services:
-
   vscsync:
     image: lolinternet/vscsync:latest
     build:
-	@@ -10,28 +9,29 @@ services:
+      context: ./
+      dockerfile: ./vscoffline/vscsync/Dockerfile
+    dns:
       - 1.1.1.1
     volumes:
       # Enable for dev
@@ -21,7 +22,7 @@ services:
     image: lolinternet/vscgallery:latest
     build:
       context: ./
-      dockerfile: ./vscoffline/vscgallery/Dockerfile    
+      dockerfile: ./vscoffline/vscgallery/Dockerfile
     volumes:
       # Enable for dev
       #- ./vscoffline/:/opt/vscoffline/:ro # Enable for dev
@@ -33,3 +34,4 @@ services:
     ports:
       - 443:443
     environment:
+      - BIND=0.0.0.0:443

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -586,7 +586,7 @@ if __name__ == '__main__':
             for identity in extensions:
                 if count % 100 == 0:
                     log.info(f'Progress {count}/{len(extensions)} ({count/len(extensions)*100:.1f}%)')
-                if identity.version():
+                if extensions[identity].version():
                     extensions[identity].download_assets(config.artifactdir_extensions)
                     bonus = extensions[identity].process_embedded_extensions(config.artifactdir_extensions, mp) + bonus
                     extensions[identity].save_state(config.artifactdir_extensions)

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -388,8 +388,10 @@ class VSCMarketplace(object):
                     log.info("ProxyError: Retrying.")
                 except requests.exceptions.ReadTimeout:
                     log.info("ReadTimeout: Retrying.")
+                except requests.exceptions.ConnectionError:
+                    log.info("ConnectionError: Retrying.")
             if not result:
-                log.info("Failed 10 attempts to query marketplace. Giving up.")
+                log.info(f'Failed 10 attempts to query marketplace. Giving up searching for "{filtervalue}".')
                 break
             jresult = result.json()
             count = count + pageSize

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -595,9 +595,10 @@ if __name__ == '__main__':
                 count = count + 1
 
             for bonusextension in bonus:
-                log.debug(f'Processing Embedded Extension: {bonusextension}')
-                bonusextension.download_assets(config.artifactdir_extensions)                
-                bonusextension.save_state(config.artifactdir_extensions)
+                if bonusextension.version():
+                    log.debug(f'Processing Embedded Extension: {bonusextension}')
+                    bonusextension.download_assets(config.artifactdir_extensions)                
+                    bonusextension.save_state(config.artifactdir_extensions)
                 
         log.info('Complete')
         VSCUpdates.signal_updated(os.path.abspath(config.artifactdir))

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -586,9 +586,10 @@ if __name__ == '__main__':
             for identity in extensions:
                 if count % 100 == 0:
                     log.info(f'Progress {count}/{len(extensions)} ({count/len(extensions)*100:.1f}%)')
-                extensions[identity].download_assets(config.artifactdir_extensions)
-                bonus = extensions[identity].process_embedded_extensions(config.artifactdir_extensions, mp) + bonus
-                extensions[identity].save_state(config.artifactdir_extensions)
+                if identity.version():
+                    extensions[identity].download_assets(config.artifactdir_extensions)
+                    bonus = extensions[identity].process_embedded_extensions(config.artifactdir_extensions, mp) + bonus
+                    extensions[identity].save_state(config.artifactdir_extensions)
                 count = count + 1
 
             for bonusextension in bonus:


### PR DESCRIPTION
Until we find a better way to handle multi-versioned extensions this will skip them entirely. I've also added another exception handler to the retry logic. Discussed in #19 

Currently this logic skips about 16 extensions. So we might want to put a message somewhere about this?

Skipped extensions (as of 10/26/2021):

- actboy168.lua-debug
- redhat.vscode-openshift-connector
- BlockceptionLtd.blockceptionvscodeminecraftbedrockdevelopmentextension
- AlbinBD.run
- xsro.vscode-dosbox
- joaomoreno.vscode-platform-specific-sample
- axetroy.vscode-whatchanged
- sandy081.998-test-code
- yanzh.sample
- chrmarti.test-platform-specific-extensions
- AndresMorelos.compliance-debug-syntax
- sandy081.998-test-web-only
- RemiOlivier.pkcs11-explorer
- JoonaYoon.LFS
- sandy081.999-pse-win
- PrashantCholachagudda.eardemo 