### PR TITLE
Download non-prerelease extensions ONLY by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ artifacts/*
 __pycache__/
 temp/
 venv/
+.vscode/*

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ usage: sync.py [-h] [--sync] [--syncall] [--artifacts ARTIFACTDIR]
                [--extension-name EXTENSIONNAME]
                [--extension-search EXTENSIONSEARCH] [--update-binaries]
                [--update-extensions] [--update-malicious-extensions]
-               [--skip-binaries] [--debug] [--logfile LOGFILE]
+               [--prerelease-extensions] [--skip-binaries] 
+               [--debug] [--logfile LOGFILE]
 
 Synchronises VSCode in an Offline Environment
 
@@ -166,6 +167,8 @@ optional arguments:
   --update-extensions   Download extensions
   --update-malicious-extensions
                         Update the malicious extension list
+  --prerelease-extensions
+                        Download prerelease extensions. Defaults to false.
   --skip-binaries       Skip downloading binaries
   --debug               Show debug output
   --logfile LOGFILE     Sets a logfile to store loggging output

--- a/vscoffline/server.py
+++ b/vscoffline/server.py
@@ -161,11 +161,17 @@ class VSCGallery(object):
             name = extension['identity']
 
             # Repoint asset urls
-            asseturi = vsc.URLROOT + os.path.join(extensiondir, extension['versions'][0]['version'])
-            extension['versions'][0]['assetUri'] = asseturi
-            extension['versions'][0]['fallbackAssetUri'] = asseturi
-            for asset in extension['versions'][0]['files']:
-                asset['source'] = asseturi + '/' + asset['assetType']
+            for version in extension["versions"]:
+                if "targetPlatform" in version:
+                    targetPlatform = version['targetPlatform']
+                    asseturi = vsc.URLROOT + os.path.join(extensiondir, version['version'], targetPlatform)
+                else:                    
+                    asseturi = vsc.URLROOT + os.path.join(extensiondir, version['version'])
+
+                version['assetUri'] = asseturi
+                version['fallbackAssetUri'] = asseturi
+                for asset in version['files']:
+                    asset['source'] = asseturi + '/' + asset['assetType']
 
             # Map statistics for later lookup
             stats = {

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -7,8 +7,6 @@ from distutils.dir_util import create_tree
 
 class VSCUpdateDefinition(object):
 
-    session = requests.session()
-
     def __init__(self, platform=None, architecture=None, buildtype=None, quality=None,
             updateurl=None, name=None, version=None, productVersion=None, 
             hashs=None, timestamp=None, sha256hash=None, supportsFastUpdate=None):
@@ -53,7 +51,7 @@ class VSCUpdateDefinition(object):
         url = vsc.URL_BINUPDATES + f"{self.identity}/{self.quality}/{old_commit_id}"
         
         log.debug(f'Update url {url}')
-        result = self.session.get(url, allow_redirects=True, timeout=vsc.TIMEOUT)
+        result = requests.get(url, allow_redirects=True, timeout=vsc.TIMEOUT)
         self.checkedForUpdate = True
 
         if result.status_code == 204:
@@ -101,7 +99,7 @@ class VSCUpdateDefinition(object):
             log.debug(f'Previously downloaded {self}')
         else:
             log.info(f'Downloading {self} to {destfile}')
-            result = self.session.get(self.updateurl, allow_redirects=True, timeout=vsc.TIMEOUT)
+            result = requests.get(self.updateurl, allow_redirects=True, timeout=vsc.TIMEOUT)
             open(destfile, 'wb').write(result.content)
 
             if not vsc.Utility.hash_file_and_check(destfile, self.sha256hash):
@@ -131,8 +129,6 @@ class VSCUpdateDefinition(object):
 
 class VSCExtensionDefinition(object):
     
-    session = requests.session()
-
     def __init__(self, identity, raw=None):
         self.identity = identity
         self.extensionId = None
@@ -197,7 +193,7 @@ class VSCExtensionDefinition(object):
             create_tree(os.path.abspath(os.sep), (destfile,))
             if not os.path.exists(destfile):
                 log.debug(f'Downloading {self.identity} {asset} to {destfile}')
-                result = self.session.get(url, allow_redirects=True, timeout=vsc.TIMEOUT)
+                result = requests.get(url, allow_redirects=True, timeout=vsc.TIMEOUT)
                 with open(destfile, 'wb') as dest:
                     dest.write(result.content)
     
@@ -255,8 +251,6 @@ class VSCUpdates(object):
 
 class VSCMarketplace(object):
    
-    session = requests.session()
-
     def __init__(self, insider):
         self.insider = insider
 
@@ -282,7 +276,7 @@ class VSCMarketplace(object):
         return recommendations
 
     def get_recommendations_old(self, destination):
-        result = self.session.get(vsc.URL_RECOMMENDATIONS, allow_redirects=True, timeout=vsc.TIMEOUT)
+        result = requests.get(vsc.URL_RECOMMENDATIONS, allow_redirects=True, timeout=vsc.TIMEOUT)
         if result.status_code != 200:            
             log.warning(f"get_recommendations failed accessing url {vsc.URL_RECOMMENDATIONS}, unhandled status code {result.status_code}")
             return False
@@ -300,7 +294,7 @@ class VSCMarketplace(object):
         return packages
 
     def get_malicious(self, destination, extensions=None):
-        result = self.session.get(vsc.URL_MALICIOUS, allow_redirects=True, timeout=vsc.TIMEOUT)
+        result = requests.get(vsc.URL_MALICIOUS, allow_redirects=True, timeout=vsc.TIMEOUT)
         if result.status_code != 200:            
             log.warning(f"get_malicious failed accessing url {vsc.URL_MALICIOUS}, unhandled status code {result.status_code}")
             return False
@@ -380,7 +374,7 @@ class VSCMarketplace(object):
                 if i > 0:
                     log.info("Retrying pull page %d attempt %d." % (pageNumber, i+1))
                 try:
-                    result = self.session.post(vsc.URL_MARKETPLACEQUERY, headers=self._headers(), json=query, allow_redirects=True, timeout=vsc.TIMEOUT)
+                    result = requests.post(vsc.URL_MARKETPLACEQUERY, headers=self._headers(), json=query, allow_redirects=True, timeout=vsc.TIMEOUT)
                     if result:
                         break
                 except requests.exceptions.ProxyError:


### PR DESCRIPTION
Takes care of #31 and downloads only non-prerelease versions of extensions.

Some other updates are:
- Removed use of storing sessions with `session = requests.session()` in favor of using the the http method directly from the `requests` object. This was an attempt to fix #33.
- Added the `--prerelease-extensions` toggle to allow user to download prerelease extensions as well
- Added the `--vscode-version` arg to configure version used in **User-Agent** header. Defaults to 1.69.2, the latest version of VSCode as of today