### PR TITLE
support overriding SSL-related arguments to gunicorn

### DIFF
--- a/vscoffline/vscgallery/Dockerfile
+++ b/vscoffline/vscgallery/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7-alpine
 
 # For gunicorn > 20.0.0
-RUN apk --no-cache add libc-dev binutils 
+RUN apk --no-cache add libc-dev binutils
 
 COPY ./vscoffline/ /opt/vscoffline
 
@@ -13,8 +13,8 @@ ENV ARTIFACTS=/artifacts
 ENV BIND=0.0.0.0:443
 ENV TIMEOUT=180
 ENV THREADS=4
+ENV SSLARGS="--certfile=/opt/vscoffline/vscgallery/ssl/vscoffline.crt --keyfile=/opt/vscoffline/vscgallery/ssl/vscoffline.key"
 
-CMD gunicorn  --bind $BIND --chdir /opt/vscoffline/ \
-    --certfile=/opt/vscoffline/vscgallery/ssl/vscoffline.crt --keyfile=/opt//vscoffline/vscgallery/ssl/vscoffline.key \
+CMD gunicorn  --bind $BIND --chdir /opt/vscoffline/ $SSLARGS \
     --access-logfile - --reload --timeout $TIMEOUT --threads $THREADS \
     server:application


### PR DESCRIPTION
When HTTPS-termination is done by a reverse proxy (Caddy, Nginx, etc.), it's nice to be able to tell gunicorn to serve the page via HTTP instead of HTTPS.
With this change you can run vscgallery with something like `-e BIND=0.0.0.0:80 -e SSLARGS=` to achieve that.

---

Essentially `--certfile` and `--keyfile` are pulled out into an additional env var (`SSLARGS`), allowing users to override the arguments. If the env var isn't touched, container behavior is identical to before.