### PR TITLE
🔥 Remove deprecated `logzero` package

### DIFF
--- a/vscoffline/server.py
+++ b/vscoffline/server.py
@@ -1,12 +1,12 @@
 import os, sys, time, json, glob
 import falcon
 from distutils.version import LooseVersion
-from logzero import logger as log
 from wsgiref import simple_server
 from watchdog.observers.polling import PollingObserver
 from watchdog.events import FileSystemEventHandler
 from threading import Event, Thread
 import vsc
+import vsc.log as log
 
 
 class VSCUpdater(object):

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -13,9 +13,9 @@ import time
 import datetime
 from typing import List
 from platform import release
-from logzero import logger as log
 from pytimeparse.timeparse import timeparse
 import vsc
+import vsc.log as log
 from distutils.dir_util import create_tree
 
 

--- a/vscoffline/vsc.py
+++ b/vscoffline/vsc.py
@@ -8,7 +8,7 @@ from enum import IntFlag
 from typing import Any, Dict, List, Union
 
 log.basicConfig(
-    format='%(color)s[%(levelname)1.1s %(asctime)s %(module)s:%(lineno)d]%(end_color)s %(message)s',
+    format='[%(levelname)1.1s %(asctime)s %(module)s:%(lineno)d] %(message)s',
     datefmt='%y%m%d %H:%M:%S',
 )
 

--- a/vscoffline/vsc.py
+++ b/vscoffline/vsc.py
@@ -1,12 +1,16 @@
 import datetime
 import hashlib
 import json
+import logging as log
 import os
 import pathlib
 from enum import IntFlag
 from typing import Any, Dict, List, Union
 
-from logzero import logger as log
+log.basicConfig(
+    format='%(color)s[%(levelname)1.1s %(asctime)s %(module)s:%(lineno)d]%(end_color)s %(message)s',
+    datefmt='%y%m%d %H:%M:%S',
+)
 
 PLATFORMS = ["win32", "linux", "linux-deb", "linux-rpm", "darwin", "linux-snap", "server-linux"]
 ARCHITECTURES = ["", "x64"]

--- a/vscoffline/vscgallery/requirements.txt
+++ b/vscoffline/vscgallery/requirements.txt
@@ -1,4 +1,3 @@
-logzero
 requests
 falcon
 gunicorn

--- a/vscoffline/vscsync/requirements.txt
+++ b/vscoffline/vscsync/requirements.txt
@@ -1,3 +1,2 @@
-logzero
 requests
 pytimeparse


### PR DESCRIPTION
The [`logzero`](https://github.com/metachris/logzero) project has been archived by the owner on `Nov 28, 2022`. 
Therefore, I replaced the logging functionality with Python's built-in `logging` module.
