### PR TITLE
Fix handling of optional query filter options

### DIFF
--- a/vscoffline/server.py
+++ b/vscoffline/server.py
@@ -206,10 +206,10 @@ class VSCGallery(object):
         #flags = vsc.QueryFlags.NoneDefined
         criteria = req.media['filters'][0]['criteria']
 
-        if req.media['filters'][0]['sortOrder']:
+        if req.media['filters'][0].get('sortOrder'):
             sortorder = vsc.SortOrder(req.media['filters'][0]['sortOrder'])
 
-        if req.media['filters'][0]['sortBy']:
+        if req.media['filters'][0].get('sortBy'):
             sortby = vsc.SortBy(req.media['filters'][0]['sortBy'])
 
         # Flags can be used for version management, but it appears the client doesn't care what's sent back
@@ -217,8 +217,8 @@ class VSCGallery(object):
         #    flags = vsc.QueryFlags(req.media['flags'])
 
         # Unused
-        #pagenumber = req.media['filters'][0]['pageNumber']
-        #pagesize = req.media['filters'][0]['pageSize']
+        #pagenumber = req.media['filters'][0].get('pageNumber', 0)
+        #pagesize = req.media['filters'][0].get('pageSize', 500)
         #log.info(f'CRITERIA {criteria}, flags {flags}, sortby {sortby}, sortorder {sortorder}')
 
         # If no order specified, default to InstallCount (e.g. popular first)


### PR DESCRIPTION
Query filter options like `sortOrder` and `sortBy` are optional. The existing code handled these incorrectly, causing 500 responses.

---

This causes recent versions of `ms-vscode.cpptools` to fail activation, because the [query to check for available pre-releases](https://github.com/microsoft/vscode-cpptools/blob/7f87dc49f8da5373342c415d691e76c8f18218e3/Extension/src/LanguageServer/extension.ts#L1186) does not contain `sortOrder` or `sortedBy`.