### PR TITLE
Add server-linux-legacy to PLATFORMS in vsc.py

### DIFF
--- a/vscoffline/vsc.py
+++ b/vscoffline/vsc.py
@@ -7,7 +7,7 @@ from enum import IntFlag
 from typing import Any, Dict, List, Union
 import logging as log
 
-PLATFORMS = ["win32", "linux", "linux-deb", "linux-rpm", "darwin", "linux-snap", "server-linux", "cli-alpine"]
+PLATFORMS = ["win32", "linux", "linux-deb", "linux-rpm", "darwin", "linux-snap", "server-linux", "server-linux-legacy", "cli-alpine"]
 ARCHITECTURES = ["", "x64"]
 BUILDTYPES = ["", "archive", "user"]
 QUALITIES = ["stable", "insider"]


### PR DESCRIPTION
VSCode added a new binary type for legacy linux systems like CentOS7 in version 1.88.0