### PR TITLE
Fix makefile with tabs and add podman build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,3 @@ podman:
 
 run:
 	docker-compose up --build -d
-git 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 build:
-    pip install -r vscsync/requirements.txt
-    pip install -r vscgallery/requirements.txt
+	pip install -r vscoffline/vscsync/requirements.txt
+	pip install -r vscoffline/vscgallery/requirements.txt
 
 docker:
-    docker-compose build
+	docker-compose build
+
+podman:
+	podman-compose build
 
 run:
-    docker-compose up --build -d
+	docker-compose up --build -d
+git 


### PR DESCRIPTION
Fixes `Makefile:2: *** missing separator.  Stop.`
Validated with `cat -e -t -v {Makefile}`

Added podman for use with podman desktop with podman compose plugin