### PR TITLE
fix for recommendations issue

### DIFF
--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -404,7 +404,7 @@ class VSCMarketplace(object):
         if result.status_code != 200:
             log.warning(
                 f"get_recommendations failed accessing url {vsc.URL_RECOMMENDATIONS}, unhandled status code {result.status_code}")
-            return False
+            return {}  # Return an empty dictionary instead of False
 
         jresult = result.json()
         with open(os.path.join(destination, 'recommendations.json'), 'w') as outfile:

--- a/vscoffline/vsc.py
+++ b/vscoffline/vsc.py
@@ -7,9 +7,9 @@ from enum import IntFlag
 from typing import Any, Dict, List, Union
 import logging as log
 
-PLATFORMS = ["win32", "linux", "linux-deb", "linux-rpm", "darwin", "linux-snap", "server-linux", "server-linux-legacy", "cli-alpine"]
-ARCHITECTURES = ["", "x64"]
-BUILDTYPES = ["", "archive", "user"]
+PLATFORMS = ["win32", "linux", "linux-deb", "linux-rpm", "darwin", "darwin-arm64", "darwin-universal", "linux-snap", "server-linux", "cli-alpine", "server-darwin"]
+ARCHITECTURES = ["", "x64", "arm64", "armhf", "alpine"]
+BUILDTYPES = ["", "archive", "user", "web"]
 QUALITIES = ["stable", "insider"]
 
 URL_BINUPDATES = r"https://update.code.visualstudio.com/api/update/"


### PR DESCRIPTION
I've added a quick fix in to address the removal of the recommendations files.  https://github.com/LOLINTERNETZ/vscodeoffline/issues/81 
This works for the `syncall` arg but as sync relies on the recommendations list I'm not sure how to address it.
A more long term fix will be needed for the big adjustments Microsoft have made to the marketplace and

I also added in a few extra platforms and build types.  