### PR TITLE
Microsoft API Fix and general improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,46 +1,41 @@
 # Change Log for Visual Studio Code - Offline Gallery and Updater
 
-## [1.0.24] - 2023-06-05
+## ToDo
+- [ ] Cleanup old extension versions
+- [ ] Cleanup old binary versions
+- [ ] Include existing extensions in update process
+- [ ] Determine VSCode version automatically
+- [ ] Shorthands for command line arguments
 
+## `1.0.24` - 2023-06-05
 ### Fixed
-
 - Improvements to requests session handling to prevent ConnectionErrors due to repeated connections. Thanks @tomer953 for reporting.
 
 ### Added
-
 - Note about Firefox in Readme.md. Thanks @jmorcate for highlighting this gap.
 
 ### Changed
-
 - Sort gallery listings with simple python sort.
 - Removed deprecated logzero dependency, switched to logging. Thanks @bdsoha for the implementation and note.
 
-## [1.0.23] - 2022-11-09
-
+## `1.0.23` - 2022-11-09
 ### Fixed
-
 - @forky2 resolved an issue related to incorrect version ordering (from reverse-alphanumberical to reverse-chronological), which prevented extensions updating correctly by vscode clients.
 
-## [1.0.22] - 2022-10-31
-
+## `1.0.22` - 2022-10-31
 ### Added
-
 - @maxtruxa added support for specifying docker container environment variable `SSLARGS` to control SSL arguments, or disable SSL by setting `BIND=0.0.0.0:80` and `SSLARGS=` (empty).
 
 ### Changed
-
 - @Precioussheep improved consistency of the codebase, reducing bonus code and added typing.
 
-## [1.0.21] - 2022-08-08
-
+## `1.0.21` - 2022-08-08
 ### Added
-
 - @tomer953 added support for fetching a specified number of recommended extensions `--total-recommended`.
 - @Ebsan added support for fetching pre-release extensions `--prerelease-extensions` and fix fetching other extensions [#31](https://github.com/LOLINTERNETZ/vscodeoffline/issues/31).
 - @Ebsan added support for specifying which Visual Studio Code version to masquerade as when fetching extensions `--vscode-version`.
 
 ### Changed
-
 - Merge dependabot suggestions for CI pipeline updates.
 - Utilise individual requests, rather than a Requests session, for fetching extensions to improve stability of fetch process. Should resolve [#33](https://github.com/LOLINTERNETZ/vscodeoffline/issues/33). Thanks @Ebsan for the fix and @annieherram for reporting.
 - Updated build-in certificate and key to update its expiry [#37](https://github.com/LOLINTERNETZ/vscodeoffline/issues/37). Included CA chain aswell. Thanks for reporting @Ebsan.
@@ -48,84 +43,57 @@
 - Split out this changelog.
 
 ### Fixed
-
 - @tomer953 removed a duplicate flag to QueryFlags.
 - @Ebsan fixed an issue with downloading cross-platform extensions [#24](https://github.com/LOLINTERNETZ/vscodeoffline/issues/24).
 
-## [1.0.20]
-
+## `1.0.20`
 ### Fixed
-
 - Fixed an issue when downloading multiple versions of extensions. Thanks @forky2!
 
-## [1.0.19]
-
+## `1.0.19`
 ### Fixed
-
 - Lots of really solid bug fixes. Thank you to @fullylegit! Resilience improvements when fetching from marketplace. Thanks @forky2 and @ebsan.
 
-## [1.0.18]
-
+## `1.0.18`
 ### Changed
-
 - Meta release to trigger CI.
 
-## [1.0.17]
-
+## `1.0.17`
 ### Changed
-
 - CORS support for gallery. Thanks @kenyon!
 
-## [1.0.16]
-
+## `1.0.16`
 ### Changed
-
 - Support for saving sync logs to file. Thanks @ap0yuv!
 
-## [1.0.16]
-
+## `1.0.16`
 ### Changed
-
 - Improve extension stats handling.
 
-## [1.0.14]
-
+## `1.0.14`
 ### Fixed
-
 - Fixed insider builds being re-fetched.
 
-## [1.0.13]
-
+## `1.0.13`
 ### Added
-
 - Added initial support for extension version handling. Hopefully this resolves issue #4.
 
-## [1.0.12]
-
+## `1.0.12`
 ### Fixed
-
 - @ttutko fixed a bug preventing multiple build qualities (stable/insider) from being downloaded. Thanks @darkonejr for investigating and reporting.
 
-## [1.0.11]
-
+## `1.0.11`
 ### Fixed
-
 - Fixed bugs in Gallery sorting, and added timeouts for Sync.
 
-## [1.0.10]
-
+## `1.0.10`
 ### Changed
-
 - Refactored to improve consistency.
 
-## [1.0.9]
-
+## `1.0.9`
 ### Added
-
 - Added support for Remote Development, currently (2019-05-12) available to insiders. Refactored various badness.
 
-## [1.0.8]
-
+## `1.0.8`
 ### Added
-
 - Insiders support and extension packs (remotes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## ToDo
 - [X] Cleanup old extension versions
-- [ ] Cleanup old binary versions
+- [X] Cleanup old binary versions
 - [X] Include existing extensions in update process
 - [ ] Determine VSCode version automatically
 - [ ] Shorthands for command line arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log for Visual Studio Code - Offline Gallery and Updater
 
 ## ToDo
-- [ ] Cleanup old extension versions
+- [X] Cleanup old extension versions
 - [ ] Cleanup old binary versions
 - [ ] Include existing extensions in update process
 - [ ] Determine VSCode version automatically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## ToDo
 - [X] Cleanup old extension versions
 - [ ] Cleanup old binary versions
-- [ ] Include existing extensions in update process
+- [X] Include existing extensions in update process
 - [ ] Determine VSCode version automatically
 - [ ] Shorthands for command line arguments
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [X] Cleanup old binary versions
 - [X] Include existing extensions in update process
 - [ ] Determine VSCode version automatically
-- [ ] Shorthands for command line arguments
+- [X] Shorthands for command line arguments
 
 ## `1.0.24` - 2023-06-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Change Log for Visual Studio Code - Offline Gallery and Updater
 
-## ToDo
-- [X] Cleanup old extension versions
-- [X] Cleanup old binary versions
-- [X] Include existing extensions in update process
-- [ ] Determine VSCode version automatically
-- [X] Shorthands for command line arguments
-
 ## `1.0.24` - 2023-06-05
 ### Fixed
 - Improvements to requests session handling to prevent ConnectionErrors due to repeated connections. Thanks @tomer953 for reporting.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ On the non-Internet connected system:
 
 1. On the non-Internet connected system, ensure the following DNS addresses are pointed toward the vscgallery service.
     * update.code.visualstudio.com
-    * az764295.vo.msecnd.net
+    * main.vscode-cdn.net
     * marketplace.visualstudio.com
 
     This may be achieved using a corporate DNS server, or by modifying a client's host file.
@@ -90,7 +90,7 @@ This guide will setup the vscsync and vscgallery service on the same Docker host
 
 2. Point the DNS addresses to the vscgallery service.
     * update.code.visualstudio.com
-    * az764295.vo.msecnd.net
+    * main.vscode-cdn.net
     * marketplace.visualstudio.com
 
     This may be achieved using a corporate DNS server, or by modifying a client's host file.

--- a/README.md
+++ b/README.md
@@ -116,50 +116,48 @@ These arguments can be passed as command line arguments to sync.py  (e.g. --varA
 
  ### Possible Args:
 ```
-usage: sync.py [-h] [--sync] [--syncall] [--artifacts ARTIFACTDIR]
-               [--frequency FREQUENCY] [--check-binaries] [--check-insider]
-               [--check-recommended-extensions] [--check-specified-extensions]
-               [--extension-name EXTENSIONNAME]
-               [--extension-search EXTENSIONSEARCH] [--update-binaries]
-               [--update-extensions] [--update-malicious-extensions]
-               [--prerelease-extensions] [--vscode-version VSCODEVERSION]
-               [--skip-binaries] [--debug] [--logfile LOGFILE]
+usage: sync.py [-h] [--sync] [--syncall] [--artifacts ARTIFACTDIR] [--frequency FREQUENCY] [--check-binaries] [--check-insider] [--check-recommended-extensions] [--check-specified-extensions] [--extension-name EXTENSIONNAME] [--extension-search EXTENSIONSEARCH] [--prerelease-extensions]
+               [--update-binaries] [--update-extensions] [--update-malicious-extensions] [--skip-binaries] [--vscode-version VERSION] [--total-recommended TOTALRECOMMENDED] [--debug] [--logfile LOGFILE] [--include-existing] [--skip-existing] [--garbage-collection]
 
 Synchronises VSCode in an Offline Environment
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
-  --sync                The basic-user sync. It includes stable binaries and
-                        typical extensions
-  --syncall             The power-user sync. It includes all binaries and
-                        extensions
-  --artifacts ARTIFACTDIR
+  --sync, -s            The basic-user sync. It includes stable binaries and typical extensions
+  --syncall, -a         The power-user sync. It includes all binaries and extensions
+  --artifacts ARTIFACTDIR, -d ARTIFACTDIR
                         Path to downloaded artifacts
-  --frequency FREQUENCY
-                        The frequency to try and update (e.g. sleep for '12h'
-                        and try again
-  --total-recommended N 
-                        The number of recommended extensions to fetch
-                        (default: 200)
+  --frequency FREQUENCY, -f FREQUENCY
+                        The frequency to try and update (e.g. sleep for '12h' and try again)
   --check-binaries      Check for updated binaries
-  --check-insider       Check for updated insider binaries
+  --check-insider, -i   Check for updated insider binaries
   --check-recommended-extensions
                         Check for recommended extensions
-  --check-specified-extensions
+  --check-specified-extensions, -w
                         Check for extensions in <artifacts>/specified.json
-  --extension-name EXTENSIONNAME
+  --extension-name EXTENSIONNAME, -n EXTENSIONNAME
                         Find a specific extension by name
   --extension-search EXTENSIONSEARCH
                         Search for a set of extensions
-  --update-binaries     Download binaries
-  --update-extensions   Download extensions
-  --update-malicious-extensions
-                        Update the malicious extension list
-  --prerelease-extensions
+  --prerelease-extensions, -p
                         Download prerelease extensions. Defaults to false.
-  --vscode-version
+  --update-binaries, -b
+                        Download binaries
+  --update-extensions, -u
+                        Download extensions
+  --update-malicious-extensions, -m
+                        Update the malicious extension list
+  --skip-binaries, -B   Skip downloading binaries
+  --vscode-version VERSION, -v VERSION
                         VSCode version to search extensions as.
-  --skip-binaries       Skip downloading binaries
+  --total-recommended TOTALRECOMMENDED
+                        Total number of recommended extensions to sync from Search API. Defaults to 500
   --debug               Show debug output
-  --logfile LOGFILE     Sets a logfile to store loggging output
+  --logfile LOGFILE, -l LOGFILE
+                        Sets a logfile to store loggging output
+  --include-existing, -e
+                        Include existing extensions in the update process
+  --skip-existing, -E   Skip inclusion of existing extensions in the update process
+  --garbage-collection, -g
+                        Remove old versions of artifacts (binaries / extensions)
   ```

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -435,12 +435,11 @@ class VSCMarketplace(object):
             'utf-8', 'ignore').replace(u'\xa0', u'')
         jresult = json.loads(stripped)
 
-        for malicious in jresult['malicious']:
-            log.debug(f'Malicious extension {malicious}')
-            if malicious in extensions.keys():
+        for extension in extensions[:]:     # Iterate over a copy of the extension collection
+            if extension in jresult['malicious']:
                 log.warning(
-                    f'Preventing malicious extension {malicious} from being downloaded')
-                del extensions[malicious]
+                    f'Preventing malicious extension {extension} from being downloaded')
+                del extensions[extension]
 
     def get_specified(self, specifiedpath):
         if not os.path.exists(specifiedpath):

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -419,7 +419,11 @@ class VSCMarketplace(object):
 
         return packages
 
-    def get_malicious(self, destination, extensions=None):
+    def get_malicious(self, extensions=None):
+        if not extensions:
+            return
+
+        # Query Microsofts list
         result = self.session.get(
             vsc.URL_MALICIOUS, allow_redirects=True, timeout=vsc.TIMEOUT)
         if result.status_code != 200:
@@ -430,11 +434,6 @@ class VSCMarketplace(object):
         stripped = result.content.decode(
             'utf-8', 'ignore').replace(u'\xa0', u'')
         jresult = json.loads(stripped)
-        with open(os.path.join(destination, 'malicious.json'), 'w') as outfile:
-            json.dump(jresult, outfile, cls=vsc.MagicJsonEncoder, indent=4)
-
-        if not extensions:
-            return
 
         for malicious in jresult['malicious']:
             log.debug(f'Malicious extension {malicious}')
@@ -800,7 +799,7 @@ if __name__ == '__main__':
         if config.updatemalicious:
             log.info('Syncing VS Code Malicious Extension List')
             malicious = mp.get_malicious(
-                os.path.abspath(config.artifactdir), extensions)
+                extensions)
 
         if config.updateextensions:
             log.info(

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -705,51 +705,54 @@ class VSCMarketplace(object):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Synchronises VSCode in an Offline Environment')
-    parser.add_argument('--sync', dest='sync', action='store_true',
+    parser.add_argument('--sync', '-s', dest='sync', action='store_true',
                         help='The basic-user sync. It includes stable binaries and typical extensions')
-    parser.add_argument('--syncall', dest='syncall', action='store_true',
+    parser.add_argument('--syncall', '-a', dest='syncall', action='store_true',
                         help='The power-user sync. It includes all binaries and extensions ')
-    parser.add_argument('--artifacts', dest='artifactdir',
+    parser.add_argument('--artifacts', '-d', dest='artifactdir',
                         default='../artifacts/', help='Path to downloaded artifacts')
-    parser.add_argument('--frequency', dest='frequency', default=None,
+    parser.add_argument('--frequency', '-f', dest='frequency', default=None,
                         help='The frequency to try and update (e.g. sleep for \'12h\' and try again)')
 
     # Arguments to tweak behaviour
+    # ToDo Implement action=argparse.BooleanOptionalAction to combine --check-binaries and --skip-binaries into a single argument
     parser.add_argument('--check-binaries', dest='checkbinaries',
                         action='store_true', help='Check for updated binaries')
-    parser.add_argument('--check-insider', dest='checkinsider',
+    parser.add_argument('--check-insider', '-i', dest='checkinsider',
                         action='store_true', help='Check for updated insider binaries')
     parser.add_argument('--check-recommended-extensions', dest='checkextensions',
                         action='store_true', help='Check for recommended extensions')
-    parser.add_argument('--check-specified-extensions', dest='checkspecified',
+    parser.add_argument('--check-specified-extensions', '-w', dest='checkspecified',
                         action='store_true', help='Check for extensions in <artifacts>/specified.json')
-    parser.add_argument('--extension-name', dest='extensionname',
+    # ToDo Allow for list of names (action='extend' nargs='+')
+    parser.add_argument('--extension-name', '-n', dest='extensionname',
                         help='Find a specific extension by name')
+    # ToDo Allow for list of names (action='extend' nargs='+')
     parser.add_argument('--extension-search', dest='extensionsearch',
                         help='Search for a set of extensions')
-    parser.add_argument('--prerelease-extensions', dest='prerelease',
+    parser.add_argument('--prerelease-extensions', '-p', dest='prerelease',
                         action='store_true', help='Download prerelease extensions. Defaults to false.')
-    parser.add_argument('--update-binaries', dest='updatebinaries',
+    parser.add_argument('--update-binaries', '-b', dest='updatebinaries',
                         action='store_true', help='Download binaries')
-    parser.add_argument('--update-extensions', dest='updateextensions',
+    parser.add_argument('--update-extensions', '-u', dest='updateextensions',
                         action='store_true', help='Download extensions')
-    parser.add_argument('--update-malicious-extensions', dest='updatemalicious',
+    parser.add_argument('--update-malicious-extensions', '-m', dest='updatemalicious',
                         action='store_true', help='Update the malicious extension list')
-    parser.add_argument('--skip-binaries', dest='skipbinaries',
+    parser.add_argument('--skip-binaries', '-B', dest='skipbinaries',
                         action='store_true', help='Skip downloading binaries')
-    parser.add_argument('--vscode-version', dest='version',
+    parser.add_argument('--vscode-version', '-v', dest='version',
                         default=VSCUpdates.latest_version(), help='VSCode version to search extensions as.')
     parser.add_argument('--total-recommended', type=int, dest='totalrecommended', default=500,
                         help='Total number of recommended extensions to sync from Search API. Defaults to 500')
     parser.add_argument('--debug', dest='debug',
                         action='store_true', help='Show debug output')
-    parser.add_argument('--logfile', dest='logfile', default=None,
+    parser.add_argument('--logfile', '-l', dest='logfile', default=None,
                         help='Sets a logfile to store loggging output')
-    parser.add_argument('--include-existing', dest='existing',
+    parser.add_argument('--include-existing', '-e', dest='existing',
                         action='store_true', help='Include existing extensions in the update process')
-    parser.add_argument('--skip-existing', dest='skipExisting',
+    parser.add_argument('--skip-existing', '-E', dest='skipExisting',
                         action='store_true', help='Skip inclusion of existing extensions in the update process')
-    parser.add_argument('--garbage-collection', dest='garbageCollection',
+    parser.add_argument('--garbage-collection', '-g', dest='garbageCollection',
                         action='store_true', help='Remove old versions of artifacts (binaries / extensions)')
     config = parser.parse_args()
 

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -747,6 +747,8 @@ if __name__ == '__main__':
                         help='Sets a logfile to store loggging output')
     parser.add_argument('--include-existing', dest='existing',
                         action='store_true', help='Include existing extensions in the update process')
+    parser.add_argument('--skip-existing', dest='skipExisting',
+                        action='store_true', help='Skip inclusion of existing extensions in the update process')
     parser.add_argument('--garbage-collection', dest='garbageCollection',
                         action='store_true', help='Remove old versions of artifacts (binaries / extensions)')
     config = parser.parse_args()

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -653,7 +653,7 @@ if __name__ == '__main__':
     parser.add_argument('--artifacts', dest='artifactdir',
                         default='../artifacts/', help='Path to downloaded artifacts')
     parser.add_argument('--frequency', dest='frequency', default=None,
-                        help='The frequency to try and update (e.g. sleep for \'12h\' and try again')
+                        help='The frequency to try and update (e.g. sleep for \'12h\' and try again)')
 
     # Arguments to tweak behaviour
     parser.add_argument('--check-binaries', dest='checkbinaries',

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -4,7 +4,6 @@ import sys
 import argparse
 import requests
 import pathlib
-import hashlib
 import uuid
 import logging
 import json
@@ -17,6 +16,7 @@ from pytimeparse.timeparse import timeparse
 import vsc
 from distutils.dir_util import create_tree
 from requests.adapters import HTTPAdapter, Retry
+from packaging.version import Version
 
 
 class VSCUpdateDefinition(object):
@@ -352,6 +352,19 @@ class VSCUpdates(object):
         return versions
 
     @staticmethod
+    def latest_version(insider=False):
+        versions = VSCUpdates.latest_versions(insider)
+        latestVersion = Version('0.0.0')
+        for version in versions.items():
+            productVersion = version[1].productVersion
+            if not productVersion:
+                break
+            productVersion = Version(productVersion)
+            if productVersion > latestVersion:
+                latestVersion = productVersion
+        return str(latestVersion)
+
+    @staticmethod
     def signal_updated(artifactdir):
         signalpath = os.path.join(artifactdir, 'updated.json')
         result = {
@@ -677,7 +690,7 @@ if __name__ == '__main__':
     parser.add_argument('--skip-binaries', dest='skipbinaries',
                         action='store_true', help='Skip downloading binaries')
     parser.add_argument('--vscode-version', dest='version',
-                        default='1.69.2', help='VSCode version to search extensions as.')
+                        default=VSCUpdates.latest_version(), help='VSCode version to search extensions as.')
     parser.add_argument('--total-recommended', type=int, dest='totalrecommended', default=500,
                         help='Total number of recommended extensions to sync from Search API. Defaults to 500')
     parser.add_argument('--debug', dest='debug',

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -358,7 +358,7 @@ class VSCUpdates(object):
                     for quality in vsc.QUALITIES:
                         if quality == 'insider' and not insider:
                             continue
-                        if platform == 'win32' and architecture == 'ia32':
+                        if platform == 'win32-x64' and architecture == 'ia32':
                             continue
                         if platform == 'darwin' and (architecture != '' or buildtype != ''):
                             continue

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -783,8 +783,6 @@ if __name__ == '__main__':
         config.updateextensions = True
         config.updatemalicious = True
         config.checkspecified = True
-        if not config.frequency:
-            config.frequency = '12h'
         config.existing = True
 
     if config.syncall:

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -579,9 +579,9 @@ class VSCMarketplace(object):
         extensions=[]
         for extension in glob.glob(os.path.join(artifactdir_extensions, '*', 'latest.json')):
             manifest = vsc.Utility.load_json(extension)
-            result = self.search_by_extension_id(manifest['identity'])
+            result = self.search_by_extension_id(manifest['extensionId'])
             if result:
-                extensions += result
+                extensions.append(result)
         return extensions
 
     def _query_marketplace(self, filtertype, filtervalue, pageNumber=0, pageSize=500, limit=0, sortOrder=vsc.SortOrder.Default, sortBy=vsc.SortBy.NoneOrRelevance, queryFlags=0):

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -705,55 +705,120 @@ class VSCMarketplace(object):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Synchronises VSCode in an Offline Environment')
-    parser.add_argument('--sync', '-s', dest='sync', action='store_true',
-                        help='The basic-user sync. It includes stable binaries and typical extensions')
-    parser.add_argument('--syncall', '-a', dest='syncall', action='store_true',
-                        help='The power-user sync. It includes all binaries and extensions ')
-    parser.add_argument('--artifacts', '-d', dest='artifactdir',
-                        default='../artifacts/', help='Path to downloaded artifacts')
-    parser.add_argument('--frequency', '-f', dest='frequency', default=None,
-                        help='The frequency to try and update (e.g. sleep for \'12h\' and try again)')
+    parser.add_argument('--sync', '-s',
+                        dest='sync',
+                        action='store_true',
+                        help='The basic-user sync. It includes stable binaries and typical extensions'
+    )
+    parser.add_argument('--syncall', '-a',
+                        dest='syncall',
+                        action='store_true',
+                        help='The power-user sync. It includes all binaries and extensions'
+    )
+    parser.add_argument('--artifacts', '-d',
+                        dest='artifactdir',
+                        default='../artifacts/',
+                        help='Path to downloaded artifacts'
+    )
+    parser.add_argument('--frequency', '-f',
+                        dest='frequency',
+                        default=None,
+                        help='The frequency to try and update (e.g. sleep for \'12h\' and try again)'
+    )
 
     # Arguments to tweak behaviour
     # ToDo Implement action=argparse.BooleanOptionalAction to combine --check-binaries and --skip-binaries into a single argument
-    parser.add_argument('--check-binaries', dest='checkbinaries',
-                        action='store_true', help='Check for updated binaries')
-    parser.add_argument('--check-insider', '-i', dest='checkinsider',
-                        action='store_true', help='Check for updated insider binaries')
-    parser.add_argument('--check-recommended-extensions', dest='checkextensions',
-                        action='store_true', help='Check for recommended extensions')
-    parser.add_argument('--check-specified-extensions', '-w', dest='checkspecified',
-                        action='store_true', help='Check for extensions in <artifacts>/specified.json')
+    parser.add_argument('--check-binaries',
+                        dest='checkbinaries',
+                        action='store_true',
+                        help='Check for updated binaries'
+    )
+    parser.add_argument('--check-insider', '-i',
+                        dest='checkinsider',
+                        action='store_true',
+                        help='Check for updated insider binaries'
+    )
+    parser.add_argument('--check-recommended-extensions',
+                        dest='checkextensions',
+                        action='store_true',
+                        help='Check for recommended extensions'
+    )
+    parser.add_argument('--check-specified-extensions', '-w',
+                        dest='checkspecified',
+                        action='store_true',
+                        help='Check for extensions in <artifacts>/specified.json'
+    )
     # ToDo Allow for list of names (action='extend' nargs='+')
-    parser.add_argument('--extension-name', '-n', dest='extensionname',
-                        help='Find a specific extension by name')
+    parser.add_argument('--extension-name', '-n',
+                        dest='extensionname',
+                        help='Find a specific extension by name'
+    )
     # ToDo Allow for list of names (action='extend' nargs='+')
-    parser.add_argument('--extension-search', dest='extensionsearch',
-                        help='Search for a set of extensions')
-    parser.add_argument('--prerelease-extensions', '-p', dest='prerelease',
-                        action='store_true', help='Download prerelease extensions. Defaults to false.')
-    parser.add_argument('--update-binaries', '-b', dest='updatebinaries',
-                        action='store_true', help='Download binaries')
-    parser.add_argument('--update-extensions', '-u', dest='updateextensions',
-                        action='store_true', help='Download extensions')
-    parser.add_argument('--update-malicious-extensions', '-m', dest='updatemalicious',
-                        action='store_true', help='Update the malicious extension list')
-    parser.add_argument('--skip-binaries', '-B', dest='skipbinaries',
-                        action='store_true', help='Skip downloading binaries')
-    parser.add_argument('--vscode-version', '-v', dest='version',
-                        default=VSCUpdates.latest_version(), help='VSCode version to search extensions as.')
-    parser.add_argument('--total-recommended', type=int, dest='totalrecommended', default=500,
-                        help='Total number of recommended extensions to sync from Search API. Defaults to 500')
-    parser.add_argument('--debug', dest='debug',
-                        action='store_true', help='Show debug output')
-    parser.add_argument('--logfile', '-l', dest='logfile', default=None,
-                        help='Sets a logfile to store loggging output')
-    parser.add_argument('--include-existing', '-e', dest='existing',
-                        action='store_true', help='Include existing extensions in the update process')
-    parser.add_argument('--skip-existing', '-E', dest='skipExisting',
-                        action='store_true', help='Skip inclusion of existing extensions in the update process')
-    parser.add_argument('--garbage-collection', '-g', dest='garbageCollection',
-                        action='store_true', help='Remove old versions of artifacts (binaries / extensions)')
+    parser.add_argument('--extension-search',
+                        dest='extensionsearch',
+                        help='Search for a set of extensions'
+    )
+    parser.add_argument('--prerelease-extensions', '-p',
+                        dest='prerelease',
+                        action='store_true',
+                        help='Download prerelease extensions. Defaults to false.'
+    )
+    parser.add_argument('--update-binaries', '-b',
+                        dest='updatebinaries',
+                        action='store_true',
+                        help='Download binaries'
+    )
+    parser.add_argument('--update-extensions', '-u',
+                        dest='updateextensions',
+                        action='store_true',
+                        help='Download extensions'
+    )
+    parser.add_argument('--update-malicious-extensions', '-m',
+                        dest='updatemalicious',
+                        action='store_true',
+                        help='Update the malicious extension list'
+    )
+    parser.add_argument('--skip-binaries', '-B',
+                        dest='skipbinaries',
+                        action='store_true',
+                        help='Skip downloading binaries'
+    )
+    parser.add_argument('--vscode-version', '-v',
+                        dest='version',
+                        default=VSCUpdates.latest_version(),
+                        help='VSCode version to search extensions as.'
+    )
+    parser.add_argument('--total-recommended',
+                        type=int,
+                        dest='totalrecommended',
+                        default=500,
+                        help='Total number of recommended extensions to sync from Search API. Defaults to 500'
+    )
+    parser.add_argument('--debug',
+                        dest='debug',
+                        action='store_true',
+                        help='Show debug output'
+    )
+    parser.add_argument('--logfile', '-l',
+                        dest='logfile',
+                        default=None,
+                        help='Sets a logfile to store loggging output'
+    )
+    parser.add_argument('--include-existing', '-e',
+                        dest='existing',
+                        action='store_true',
+                        help='Include existing extensions in the update process'
+    )
+    parser.add_argument('--skip-existing', '-E',
+                        dest='skipExisting',
+                        action='store_true',
+                        help='Skip inclusion of existing extensions in the update process'
+    )
+    parser.add_argument('--garbage-collection', '-g',
+                        dest='garbageCollection',
+                        action='store_true',
+                        help='Remove old versions of artifacts (binaries / extensions)'
+    )
     config = parser.parse_args()
 
     if config.debug:

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -487,7 +487,7 @@ class VSCMarketplace(object):
             'utf-8', 'ignore').replace(u'\xa0', u'')
         jresult = json.loads(stripped)
 
-        for extension in extensions[:]:     # Iterate over a copy of the extension collection
+        for extension in (extensions.copy()):
             if extension in jresult['malicious']:
                 log.warning(
                     f'Preventing malicious extension {extension} from being downloaded')

--- a/vscoffline/vsc.py
+++ b/vscoffline/vsc.py
@@ -13,9 +13,9 @@ BUILDTYPES = ["", "archive", "user"]
 QUALITIES = ["stable", "insider"]
 
 URL_BINUPDATES = r"https://update.code.visualstudio.com/api/update/"
-URL_RECOMMENDATIONS = r"https://az764295.vo.msecnd.net/extensions/workspaceRecommendations.json.gz"
+URL_RECOMMENDATIONS = r"https://main.vscode-cdn.net/extensions/marketplace.json"
 URL_MARKETPLACEQUERY = r"https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery"
-URL_MALICIOUS = r"https://az764295.vo.msecnd.net/extensions/marketplace.json"
+URL_MALICIOUS = r"https://main.vscode-cdn.net/extensions/marketplace.json"
 
 URLROOT = "https://update.code.visualstudio.com"
 ARTIFACTS = "/artifacts/"

--- a/vscoffline/vsc.py
+++ b/vscoffline/vsc.py
@@ -7,7 +7,7 @@ from enum import IntFlag
 from typing import Any, Dict, List, Union
 import logging as log
 
-PLATFORMS = ["win32", "linux", "linux-deb", "linux-rpm", "darwin", "darwin-arm64", "darwin-universal", "linux-snap", "server-linux", "server-linux-legacy", "cli-alpine"]
+PLATFORMS = ["win32-x64", "linux", "linux-deb", "linux-rpm", "darwin", "darwin-arm64", "darwin-universal", "linux-snap", "server-linux", "server-linux-legacy", "cli-alpine"]
 ARCHITECTURES = ["", "x64", "arm64", "armhf", "alpine"]
 BUILDTYPES = ["", "archive", "user", "web"]
 QUALITIES = ["stable", "insider"]

--- a/vscoffline/vscsync/requirements.txt
+++ b/vscoffline/vscsync/requirements.txt
@@ -1,3 +1,4 @@
 requests
 pytimeparse
 setuptools
+packaging


### PR DESCRIPTION
- Fixed a typo
- Removed output to `malicious.json` as the file isn't used anywhere. I suspect this will speed up execution, though I haven't verified this
- Instead of iterating over every single malicious extension, only iterate the specified extensions and check if they are a part of the malicious list.
- Query newest VS Code version instead of hardcoding it. Though this will increase runtime when no version is specified, as the query will have to complete first
- Added a garbage collector to delete old artifacts like binaries and extensions
- Removed default update frequency for sync (so that per default the command only runs a single time). This is probably controversial, but as script this makes more sense imho. For the docker container the default args could be modified to still stay the same?
- Fix the Microsoft API change which blocked downloading extensions (see #81)
- Also implemented the platform change from `win32` to `win32-x64`. Thanks @AndreasAhlbeck (https://github.com/LOLINTERNETZ/vscodeoffline/issues/81#issuecomment-2838539698) 
- Added shorthands for most arguments
- Update the README to both reflect the API changes (new domain) and the added arguments