### PR TITLE
Fix sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,34 +2,37 @@
 
 This enables Visual Studio Code's web presence to be mirrored for seamless use in an offline environment (e.g. air-gapped), or to run a private gallery.
 
-In effect, content is served through expected interfaces, without changing any of the publicly available binaries. Typically, you would sync the content needing to be availabe on the non-Internet connected system and point the DNS to the mirror service. __No binaries nor extensions are modified.__
-
+In effect, content is served through expected interfaces, without changing any of the publicly available binaries. Typically, you would sync the content needing to be availabe on the non-Internet connected system and point the DNS to the mirror service. **No binaries nor extensions are modified.**
 
 ## Features
 
 On the Internet connected system , **vscsync** will:
-* Mirror the VS Code installer/update binaries across platforms (Windows|Linux|Darwin) and builds (stable|insider);
-* Mirror recommended/typical extensions from the marketplace;
-* Mirror the malicious extension list; 
-* Mirror a list of manually specified extensions (artifacts/specified.json); and
-* Optionally, mirror all extensions (--syncall, rather than the default of --sync).
+
+- Mirror the VS Code installer/update binaries across platforms (Windows|Linux|Darwin) and builds (stable|insider);
+- Mirror recommended/typical extensions from the marketplace;
+- Mirror the malicious extension list;
+- Mirror a list of manually specified extensions (artifacts/specified.json); and
+- Optionally, mirror all extensions (--syncall, rather than the default of --sync).
 
 On the non-Internet connected system, **vscgallery**:
-* Implements the updater interface to enable offline updating;
-* Implements the extension API to enable offline extension use;
-* Implements the malicious extension list; 
-* Implements initial support for multiple versions;
-* Supports extension search (name, author and short description) and sorting;
-* Supports custom/private extensions (follow the structure of a mirrored extension); and
-* Supports Remote Development.
+
+- Implements the updater interface to enable offline updating;
+- Implements the extension API to enable offline extension use;
+- Implements the malicious extension list;
+- Implements initial support for multiple versions;
+- Supports extension search (name, author and short description) and sorting;
+- Supports custom/private extensions (follow the structure of a mirrored extension); and
+- Supports Remote Development.
 
 Possible TODO List:
-* vscgallery - Support paging, if it's really needed (who searches 1000s of extensions anyway).
-* Investigate some form of dependency handling (if possible).
-* Add test cases.
+
+- vscgallery - Support paging, if it's really needed (who searches 1000s of extensions anyway).
+- Investigate some form of dependency handling (if possible).
+- Add test cases.
 
 ## Requirements
-* Docker (ideally with docker-compose for simplicity)
+
+- Docker (ideally with docker-compose for simplicity)
 
 ## Getting Started - Full Offline Use - Using Docker Containers
 
@@ -37,85 +40,93 @@ There are two components, **vscsync** which mirrors the content on an Internet c
 
 On the Internet connected system:
 
-1. Acquire/mirror the Docker containers (vscsync/vscgallery). 
+1. Acquire/mirror the Docker containers (vscsync/vscgallery).
 
-    `docker-compose pull`
+   `docker-compose pull`
 
 2. Setup and run the vscsync service on the Internet connected system.
-    * Ensuring the artifact directory is accessible to whatever transfer mechanism you will use and vscsync.
-    * Run vscsync service and ensure the artifacts are generated.
-    * Wait for the sync to complete. You should see 'Complete' and that it is sleeping when the artifacts have finished downloading.
 
-    `docker-compose up vscsync`
+   - Ensuring the artifact directory is accessible to whatever transfer mechanism you will use and vscsync.
+   - Run vscsync service and ensure the artifacts are generated.
+   - Wait for the sync to complete. You should see 'Complete' and that it is sleeping when the artifacts have finished downloading.
 
-4. Copy the artifacts to the non-Internet connected system.
+   `docker-compose up vscsync`
+
+3. Copy the artifacts to the non-Internet connected system.
 
 On the non-Internet connected system:
 
 1. On the non-Internet connected system, ensure the following DNS addresses are pointed toward the vscgallery service.
-    * update.code.visualstudio.com
-    * az764295.vo.msecnd.net
-    * marketplace.visualstudio.com
 
-    This may be achieved using a corporate DNS server, or by modifying a client's host file.
+   - update.code.visualstudio.com
+   - az764295.vo.msecnd.net
+   - marketplace.visualstudio.com
 
-2. Sort out SSL/TLS within your environment to support offline use. 
-    * Either create a certificate which is signed for the above domains, and is trusted by the clients; or
-    * Deploy the bundled root and intermediate certificate authority (vscoffline/vscgallery/ssl/ca.crt and ia.crt), with the obvious security tradeoff.
+   This may be achieved using a corporate DNS server, or by modifying a client's host file.
 
-    **Windows 10**: Import the certificates into the machine's trusted root certificate authority (Start > "Manage Computer Certificates").
+2. Sort out SSL/TLS within your environment to support offline use.
 
-    **Darwin**: Import the certificates into the machine's trusted root certificate authority.
+   - Either create a certificate which is signed for the above domains, and is trusted by the clients; or
+   - Deploy the bundled root and intermediate certificate authority (vscoffline/vscgallery/ssl/ca.crt and ia.crt), with the obvious security tradeoff.
 
-    **Ubuntu**: Easiest method seems to be Open Chrome, navigate to 
-    chrome://settings/certificates, select authorities and add the certificates. Firefox on Ubuntu maintains its own certificate store. Either add the root CA, or switch Firefox to use OS provided certificates (see: https://github.com/LOLINTERNETZ/vscodeoffline/issues/43#issuecomment-1545801875). 
+   **Windows 10**: Import the certificates into the machine's trusted root certificate authority (Start > "Manage Computer Certificates").
+
+   **Darwin**: Import the certificates into the machine's trusted root certificate authority.
+
+   **Ubuntu**: Easiest method seems to be Open Chrome, navigate to
+   chrome://settings/certificates, select authorities and add the certificates. Firefox on Ubuntu maintains its own certificate store. Either add the root CA, or switch Firefox to use OS provided certificates (see: <https://github.com/LOLINTERNETZ/vscodeoffline/issues/43#issuecomment-1545801875>).
 
 3. Run the vscgallery service, ensuring the artifacts are accessible to the service. It needs to listen on port 443.
 
-    `docker-compose up vscgallery`
+   `docker-compose up vscgallery`
 
-4. Using Chrome/Firefox navigate to https://update.code.visualstudio.com. You should not see any certificate warnings, if you do it's unlikely to work in VS Code.
+4. Using Chrome/Firefox navigate to <https://update.code.visualstudio.com>. You should not see any certificate warnings, if you do it's unlikely to work in VS Code.
 
 5. Open VS Code, hopefully you can magically install extensions and update the install. The Help > Developer Tools > Network should tell you what is going on.
 
 Note: Chrome, rather than other browsers, will likely give you a better indication as to what is going on as VS Code and Chrome share the same certificate trust.
 
-
 ## Getting Started - Standalone Install (Testing or Private Gallery) - Using Docker Containers
-This guide will setup the vscsync and vscgallery service on the same Docker host. 
+
+This guide will setup the vscsync and vscgallery service on the same Docker host.
 
 1. Grab the docker-compose.yml file.
-    * Ensure the docker-compose DNS configuration will override what is configured in step 2 (e.g. vscsync can access the Internet, whereas local hosts are directed toward the vscgallery service).
-    * Ensure both containers will mount the same artifact folder.
+
+   - Ensure the docker-compose DNS configuration will override what is configured in step 2 (e.g. vscsync can access the Internet, whereas local hosts are directed toward the vscgallery service).
+   - Ensure both containers will mount the same artifact folder.
 
 2. Point the DNS addresses to the vscgallery service.
-    * update.code.visualstudio.com
-    * az764295.vo.msecnd.net
-    * marketplace.visualstudio.com
 
-    This may be achieved using a corporate DNS server, or by modifying a client's host file.
+   - update.code.visualstudio.com
+   - ~~az764295.vo.msecnd.net~~ (Removed 2025/08/22)
+   - marketplace.visualstudio.com
+   - main.vscode-cdn.net (Added 2025/08/22)
+
+   This may be achieved using a corporate DNS server, or by modifying a client's host file.
 
 3. Deploy SSL/TLS certificates as necessary, as described above.
 
 4. Run the services
 
-    `docker-compose up`
+   `docker-compose up`
 
 5. Using Chrome navigate to https://update.code.visualstudio.com. You should not see any certificate warnings, if you do it's unlikely to work in VS Code.
 
 6. Open VS Code, hopefully you can magically install extensions and update the install. The Help > Developer Tools > Network should tell you what is going on.
 
-
 ## Sync Arguments (vscsync)
-These arguments can be passed as command line arguments to sync.py  (e.g. --varA or --varB), or passed via the Docker environment variable `SYNCARGS`.
 
-### Typical Sync Args:
- * `--sync` To fetch stable binaries and popular extensions.
- * `--syncall` To fetch everything (stable binaries, insider binaries and all extensions).
- * `--sync --check-insider` To fetch stable binaries, insider binaries and popular extensions.
+These arguments can be passed as command line arguments to sync.py (e.g. --varA or --varB), or passed via the Docker environment variable `SYNCARGS`.
 
- ### Possible Args:
-```
+### Typical Sync Args
+
+- `--sync` To fetch stable binaries and popular extensions.
+- `--syncall` To fetch everything (stable binaries, insider binaries and all extensions).
+- `--sync --check-insider` To fetch stable binaries, insider binaries and popular extensions.
+
+### Possible Args
+
+```text
 usage: sync.py [-h] [--sync] [--syncall] [--artifacts ARTIFACTDIR]
                [--frequency FREQUENCY] [--check-binaries] [--check-insider]
                [--check-recommended-extensions] [--check-specified-extensions]
@@ -138,7 +149,7 @@ optional arguments:
   --frequency FREQUENCY
                         The frequency to try and update (e.g. sleep for '12h'
                         and try again
-  --total-recommended N 
+  --total-recommended N
                         The number of recommended extensions to fetch
                         (default: 200)
   --check-binaries      Check for updated binaries
@@ -162,4 +173,4 @@ optional arguments:
   --skip-binaries       Skip downloading binaries
   --debug               Show debug output
   --logfile LOGFILE     Sets a logfile to store loggging output
-  ```
+```

--- a/vscoffline/sync.py
+++ b/vscoffline/sync.py
@@ -119,6 +119,11 @@ class VSCUpdateDefinition(object):
         if os.path.exists(destfile) and vsc.Utility.hash_file_and_check(destfile, self.sha256hash):
             log.debug(f'Previously downloaded {self}')
         else:
+            # Some old releases (e.g. stable/win32 - Version: 1.83.1) still reference the old CDN and fail the download,
+            # so these are skipped.
+            if self.updateurl.startswith("https://az764295.vo.msecnd.net"):
+                log.info(f"Skipping old version, no longer available {self}")
+                return False
             log.info(f'Downloading {self} to {destfile}')
             result = requests.get(
                 self.updateurl, allow_redirects=True, timeout=vsc.TIMEOUT)
@@ -372,20 +377,20 @@ class VSCMarketplace(object):
 
     def get_recommendations(self, destination, totalrecommended):
         recommendations = self.search_top_n(totalrecommended)
-        recommended_old = self.get_recommendations_old(destination)
+        # recommended_old = self.get_recommendations_old(destination)
 
-        for extension in recommendations:
-            # If the extension has already been found then prevent it from being collected again when processing the old recommendation list
-            if extension.identity in recommended_old.keys():
-                del recommended_old[extension.identity]
+        # for extension in recommendations:
+        #     # If the extension has already been found then prevent it from being collected again when processing the old recommendation list
+        #     if extension.identity in recommended_old.keys():
+        #         del recommended_old[extension.identity]
 
-        for packagename in recommended_old:
-            extension = self.search_by_extension_name(packagename)
-            if extension:
-                recommendations.append(extension)
-            else:
-                log.debug(
-                    f'get_recommendations failed finding a recommended extension by name for {packagename}. This extension has likely been removed.')
+        # for packagename in recommended_old:
+        #     extension = self.search_by_extension_name(packagename)
+        #     if extension:
+        #         recommendations.append(extension)
+        #     else:
+        #         log.debug(
+        #             f'get_recommendations failed finding a recommended extension by name for {packagename}. This extension has likely been removed.')
 
         prereleasecount = 0
         for recommendation in recommendations:

--- a/vscoffline/vsc.py
+++ b/vscoffline/vsc.py
@@ -13,9 +13,9 @@ BUILDTYPES = ["", "archive", "user", "web"]
 QUALITIES = ["stable", "insider"]
 
 URL_BINUPDATES = r"https://update.code.visualstudio.com/api/update/"
-URL_RECOMMENDATIONS = r"https://az764295.vo.msecnd.net/extensions/workspaceRecommendations.json.gz"
+URL_RECOMMENDATIONS = r"https://main.vscode-cdn.net/extensions/workspaceRecommendations.json.gz"
 URL_MARKETPLACEQUERY = r"https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery"
-URL_MALICIOUS = r"https://az764295.vo.msecnd.net/extensions/marketplace.json"
+URL_MALICIOUS = r"https://main.vscode-cdn.net/extensions/marketplace.json"
 
 URLROOT = "https://update.code.visualstudio.com"
 ARTIFACTS = "/artifacts/"


### PR DESCRIPTION
Resolves #81. Thanks to @SpeedyH30 for identifying the issue, @AndreasAhlbeck for identifying the fix, @moritzgrede for a suggested PR.
 - Updates the CDN url per #81 
 - Disables the 'old' fetch for recommended extensions, falling back to fetching the top 200-500 extensions. Per #81 suggestion. Per my comment in #87, I think there's still a fetch for recommended extensions which needs to be found and included.
 - Additional fix to skip downloading binaries still present on the old dead CDN.
 - Updated the README.md URLs, and formatting to suggested format.
