### PR TITLE
Create missing artifact directories automatically

### DIFF
--- a/vscoffline/server.py
+++ b/vscoffline/server.py
@@ -396,16 +396,16 @@ class ArtifactChangedHandler(FileSystemEventHandler):
 
 
 if not os.path.exists(vsc.ARTIFACTS):
-    log.warning(f'Artifact directory missing {vsc.ARTIFACTS}. Cannot proceed.')
-    sys.exit(-1)
+    log.warning(f'Artifact directory missing {vsc.ARTIFACTS}. Creating it.')
+    os.makedirs(vsc.ARTIFACTS, exist_ok=True)
 
 if not os.path.exists(vsc.ARTIFACTS_INSTALLERS):
-    log.warning(f'Installer artifact directory missing {vsc.ARTIFACTS_INSTALLERS}. Cannot proceed.')
-    sys.exit(-1)
+    log.warning(f'Installer artifact directory missing {vsc.ARTIFACTS_INSTALLERS}. Creating it.')
+    os.makedirs(vsc.ARTIFACTS_INSTALLERS, exist_ok=True)
 
 if not os.path.exists(vsc.ARTIFACTS_EXTENSIONS):
-    log.warning(f'Extensions artifact directory missing {vsc.ARTIFACTS_EXTENSIONS}. Cannot proceed.')
-    sys.exit(-1)
+    log.warning(f'Extensions artifact directory missing {vsc.ARTIFACTS_EXTENSIONS}. Creating it.')
+    os.makedirs(vsc.ARTIFACTS_EXTENSIONS, exist_ok=True)
 
 vscgallery = VSCGallery()
 


### PR DESCRIPTION
Replaced hard exit checks with automatic directory creation in vscgallery server Changed sys.exit(-1) to os.makedirs() for ARTIFACTS, ARTIFACTS_INSTALLERS, and ARTIFACTS_EXTENSIONS directories

Enable vscgallery to start successfully when vscsync runs with --skip-binaries flag Improve robustness by handling missing directories gracefully instead of failing